### PR TITLE
Pre-Caching must communicate Processing Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ log
 
 #Project Files
 .project
+.includepath

--- a/lib/Cache/Files.pm
+++ b/lib/Cache/Files.pm
@@ -271,7 +271,15 @@ sub getAsyncCache
 
 sub getCache
 {
-  return $_[0]->getAsyncCache(@_[1..$#_])->get;
+	my $readwatch = $_[0]->getAsyncCache(@_[1..$#_]);
+
+
+  #Force synchronous Processing
+  $readwatch->await;
+
+
+  #Communicate Success
+  return $readwatch->is_done;
 }
 
 

--- a/lib/Cache/Files.pm
+++ b/lib/Cache/Files.pm
@@ -1,6 +1,6 @@
 
 # @author Bodo (Hugo) Barwich
-# @version 2021-09-12
+# @version 2021-11-20
 # @package Plack Twiggy REST API
 # @subpackage Cache/Files.pm
 
@@ -37,6 +37,8 @@ use Digest::MD5 qw(md5_hex);
 
 use Path::Tiny;
 use AnyEvent::Future;
+
+use Data::Dump qw(dump);
 
 
 
@@ -89,13 +91,13 @@ sub setAsyncCache
   my $writewatch = AnyEvent::Future->new;
 
 
-  #print "'" . (caller(0))[3] . "' - go ...\n";
+  print "'" . (caller(0))[3] . "' - go ...\n";
 
   $writewatch->on_fail(\&Cache::Files::_printWatchError);
 
   $self->_writeAsyncCache($writewatch, @_[1..$#_]);
 
-  #print "'" . (caller(0))[3] . "' - done.\n";
+  print "'" . (caller(0))[3] . "' - done.\n";
 
 
   return $writewatch;
@@ -103,7 +105,15 @@ sub setAsyncCache
 
 sub setCache
 {
-  return $_[0]->setAsyncCache(@_[1..$#_])->get;
+  my $writewatch = $_[0]->setAsyncCache(@_[1..$#_]);
+
+
+  #Force synchronous Processing
+  $writewatch->await;
+
+
+  #Communicate Success
+  return $writewatch->is_done;
 }
 
 sub _readAsyncCache
@@ -117,7 +127,6 @@ sub _readAsyncCache
   {
     my $cachefile = undef;
     my $skeymd5 = md5_hex($scachekey);
-    my $irs = 0;
 
 
     $cachefile = path($self->cachemaindirectory, '/' . substr($skeymd5, 0, 1)
@@ -135,13 +144,13 @@ sub _readAsyncCache
 
       if($@)
       {
-        my $irs = 0 + $! ;
+        my $ierr = 0 + $! ;
 
 
         $@ = {'msg' => $@} unless(ref $@);
 
         $readwatch->fail({'key' => $scachekey, 'operation' => 'Get', 'file' => $cachefile->stringify
-          , 'errorcode' => $irs, 'errormessage' => $! , 'exception' => $@ });
+          , 'errorcode' => $ierr, 'errormessage' => $! , 'exception' => $@ });
       } #if($@)
     }
     else  #The Cache Key does not exist
@@ -204,13 +213,13 @@ sub _writeAsyncCache
 
     if($@)
     {
-      my $irs = 0 + $! ;
+      my $ierr = 0 + $! ;
 
 
       $@ = {'msg' => $@} unless(ref $@);
 
       $writewatch->fail({'key' => $scachekey, 'operation' => 'Set', 'file' => $cachefile->stringify
-        , 'errorcode' => $irs, 'errormessage' => $! , 'exception' => $@ });
+        , 'errorcode' => $ierr, 'errormessage' => $! , 'exception' => $@ });
     } #if($@)
   }
   else  #Cache Key missing
@@ -236,6 +245,8 @@ sub _printWatchError
     , $rhsherr->{'errorcode'}, "]: '", $rhsherr->{'errormessage'} , "'\n";
   print STDERR "File '", $rhsherr->{'file'}, "' - Exception Message: '"
     , $rhsherr->{'exception'}->{'msg'}  , "'\n";
+
+  print "'" . (caller(0))[3] . "' - done.\n";
 }
 
 

--- a/lib/Cache/Files.pm
+++ b/lib/Cache/Files.pm
@@ -1,6 +1,6 @@
 
 # @author Bodo (Hugo) Barwich
-# @version 2021-11-20
+# @version 2021-11-21
 # @package Plack Twiggy REST API
 # @subpackage Cache/Files.pm
 
@@ -272,14 +272,21 @@ sub getAsyncCache
 sub getCache
 {
 	my $readwatch = $_[0]->getAsyncCache(@_[1..$#_]);
+	my $sdata = '';
 
 
   #Force synchronous Processing
   $readwatch->await;
 
+  #Check for Success
+  if($readwatch->is_done)
+  {
+  	#Pick only Data Field from the Result
+  	$sdata = ($readwatch->result())[2];
+  }
 
-  #Communicate Success
-  return $readwatch->is_done;
+  #Return resulting Data
+  return $sdata;
 }
 
 

--- a/lib/Cache/Files.pm
+++ b/lib/Cache/Files.pm
@@ -38,7 +38,7 @@ use Digest::MD5 qw(md5_hex);
 use Path::Tiny;
 use AnyEvent::Future;
 
-use Data::Dump qw(dump);
+#use Data::Dump qw(dump);
 
 
 
@@ -91,13 +91,13 @@ sub setAsyncCache
   my $writewatch = AnyEvent::Future->new;
 
 
-  print "'" . (caller(0))[3] . "' - go ...\n";
+  #print "'" . (caller(0))[3] . "' - go ...\n";
 
   $writewatch->on_fail(\&Cache::Files::_printWatchError);
 
   $self->_writeAsyncCache($writewatch, @_[1..$#_]);
 
-  print "'" . (caller(0))[3] . "' - done.\n";
+  #print "'" . (caller(0))[3] . "' - done.\n";
 
 
   return $writewatch;
@@ -163,8 +163,6 @@ sub _readAsyncCache
       #Mark Request as done
       $readwatch->done($scachekey, $rhshrequest, $sdata);
 
-#      $readwatch->fail({'key' => $scachekey, 'operation' => 'Get', 'file' => $cachefile->stringify
-#        , 'errorcode' => 2, 'errormessage' => 'Cache Key not found!', 'exception' => {'msg' => $smsg} });
     } #if($cachefile->exists)
   }
   else  #Cache Key missing
@@ -174,8 +172,7 @@ sub _readAsyncCache
 
     $readwatch->fail({'key' => 'undefined', 'operation' => 'Get', 'file' => ''
       , 'errorcode' => 3, 'errormessage' => 'Cache Key missing!', 'exception' => {'msg' => $smsg}});
-  } #if(defined $scachekey
-    # && $scachekey ne '')
+  } #if(defined $scachekey && $scachekey ne '')
 }
 
 sub _writeAsyncCache
@@ -228,8 +225,7 @@ sub _writeAsyncCache
 
     $writewatch->fail({'key' => 'undefined', 'operation' => 'Set', 'file' => ''
       , 'errorcode' => 3, 'errormessage' => 'Cache Key missing!', 'exception' => {'msg' => $smsg} });
-  } #if(defined $scachekey
-    # && $scachekey ne '')
+  } #if(defined $scachekey && $scachekey ne '')
 }
 
 sub _printWatchError
@@ -246,7 +242,7 @@ sub _printWatchError
   print STDERR "File '", $rhsherr->{'file'}, "' - Exception Message: '"
     , $rhsherr->{'exception'}->{'msg'}  , "'\n";
 
-  print "'" . (caller(0))[3] . "' - done.\n";
+  #print "'" . (caller(0))[3] . "' - done.\n";
 }
 
 

--- a/lib/Product/Factory.pm
+++ b/lib/Product/Factory.pm
@@ -252,7 +252,7 @@ sub saveProductList
 
 	      unless($self->cache->setCache($scachekey, \$surlsjson))
 	      {
-	        print STDERR "Product List ($ioffset / $icount): Cache could not be saved!";
+	        print STDERR "Product List ($ioffset / $icount): Cache '$scachekey' could not be saved!";
 
 	        $irs = 0;
 	      }
@@ -260,7 +260,7 @@ sub saveProductList
 
       if($@)
       {
-        print STDERR "Product List ($ioffset / $icount): Cache could not be saved!";
+        print STDERR "Product List ($ioffset / $icount): Cache '$scachekey' could not be saved!";
 
         $irs = 0;
       } #if($@)
@@ -275,7 +275,7 @@ sub saveProductList
 
 	        unless($self->cache->setCache($scachekey, \$sprodjson))
           {
-	          print STDERR "Product '$sprodurl': Cache could not be saved!";
+	          print STDERR "Product '$sprodurl': Cache '$scachekey' could not be saved!";
 
 	          $irs = 0;
           }
@@ -283,7 +283,7 @@ sub saveProductList
 
       	if($@)
       	{
-	        print STDERR "Product '$sprodurl': Cache could not be saved!";
+	        print STDERR "Product '$sprodurl': Cache '$scachekey' could not be saved!";
 
 	        $irs = 0;
       	}  #if($@)

--- a/lib/Product/Factory.pm
+++ b/lib/Product/Factory.pm
@@ -42,7 +42,7 @@ use Scalar::Util qw(blessed);
 use JSON;
 use AnyEvent::Future;
 
-use Data::Dump qw(dump);
+#use Data::Dump qw(dump);
 
 use constant URLLISTKEY => 'list-product-urls';
 use constant PRODUCTKEY => 'product';
@@ -316,10 +316,6 @@ sub saveProductList
 sub _printWatchError
 {
   my $rhsherr = $_[0];
-
-
-  print STDERR "wtch err dmp:\n", dump $rhsherr;
-  print STDERR "\n";
 
 
   print STDERR "Product '", $rhsherr->{'key'}, "': ", $rhsherr->{'operation'}, " Product failed with Exception ["

--- a/lib/Product/Factory.pm
+++ b/lib/Product/Factory.pm
@@ -248,7 +248,7 @@ sub saveProductList
 
       eval
       {
-	      $surlsjson = JSON::decode_json(\@arrurls);
+	      $surlsjson = JSON::encode_json(\@arrurls);
 
 	      unless($self->cache->setCache($scachekey, \$surlsjson))
 	      {

--- a/lib/Product/Factory.pm
+++ b/lib/Product/Factory.pm
@@ -1,6 +1,6 @@
 
 # @author Bodo (Hugo) Barwich
-# @version 2021-11-20
+# @version 2021-11-21
 # @package Plack Twiggy REST API
 # @subpackage Product/Factory.pm
 
@@ -248,11 +248,11 @@ sub saveProductList
 
       eval
       {
-	      $surlsjson = JSON::encode_json(\@arrurls);
+	      $surlsjson = JSON::decode_json(\@arrurls);
 
 	      unless($self->cache->setCache($scachekey, \$surlsjson))
 	      {
-	        print STDERR "Product List ($ioffset / $icount): Cache '$scachekey' could not be saved!";
+	        print STDERR "Product List ($ioffset / $icount): Cache '$scachekey' could not be saved!\n";
 
 	        $irs = 0;
 	      }
@@ -260,7 +260,16 @@ sub saveProductList
 
       if($@)
       {
-        print STDERR "Product List ($ioffset / $icount): Cache '$scachekey' could not be saved!";
+        my $ierr = 0 + $! ;
+
+
+        $@ = {'msg' => $@} unless(ref $@);
+        $ierr = -1 if($ierr == 0);
+
+        Product::Factory::_printWatchError({'key' => $scachekey, 'operation' => 'Set', 'file' => ''
+          , 'errorcode' => $ierr, 'errormessage' => $! , 'exception' => $@ });
+
+        print STDERR "Product List ($ioffset / $icount): Cache '$scachekey' could not be saved!\n";
 
         $irs = 0;
       } #if($@)
@@ -275,7 +284,7 @@ sub saveProductList
 
 	        unless($self->cache->setCache($scachekey, \$sprodjson))
           {
-	          print STDERR "Product '$sprodurl': Cache '$scachekey' could not be saved!";
+	          print STDERR "Product '$sprodurl': Cache '$scachekey' could not be saved!\n";
 
 	          $irs = 0;
           }
@@ -283,7 +292,16 @@ sub saveProductList
 
       	if($@)
       	{
-	        print STDERR "Product '$sprodurl': Cache '$scachekey' could not be saved!";
+	        my $ierr = 0 + $! ;
+
+
+	        $@ = {'msg' => $@} unless(ref $@);
+	        $ierr = -1 if($ierr == 0);
+
+	        Product::Factory::_printWatchError({'key' => $scachekey, 'operation' => 'Set', 'file' => ''
+            , 'errorcode' => $ierr, 'errormessage' => $! , 'exception' => $@ });
+
+          print STDERR "Product '$sprodurl': Cache '$scachekey' could not be saved!\n";
 
 	        $irs = 0;
       	}  #if($@)
@@ -298,6 +316,10 @@ sub saveProductList
 sub _printWatchError
 {
   my $rhsherr = $_[0];
+
+
+  print STDERR "wtch err dmp:\n", dump $rhsherr;
+  print STDERR "\n";
 
 
   print STDERR "Product '", $rhsherr->{'key'}, "': ", $rhsherr->{'operation'}, " Product failed with Exception ["

--- a/scripts/build_cache.pl
+++ b/scripts/build_cache.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # @author Bodo (Hugo) Barwich
-# @version 2021-06-19
+# @version 2021-11-20
 # @package Plack Twiggy REST API
 # @subpackage /scripts/build_cache.pl
 
@@ -90,7 +90,10 @@ use Product::Factory;
 #Executing Section
 
 
+my $ierr = 0;
+
 my $smaindir = path(__FILE__)->parent->parent->stringify;
+my $smodulename = path(__FILE__)->basename;
 
 my $cache = Cache::Files->new($smaindir . '/cache/');
 my $prodfactory = Product::Factory->new($cache);
@@ -117,8 +120,14 @@ $lstprods->setProduct('accusantium'
   , Product->new({'name' => 'Accusantium', 'link_name' => 'accusantium', 'image' => 'coffee9.jpg'}));
 
 #Save the Product List to the Cache
-$prodfactory->saveProductList($lstprods, -1, 0);
+unless($prodfactory->saveProductList($lstprods, -1, 0))
+{
+	print STDERR "Module '$smodulename': Product List could not be saved correctly!\n";
+
+	$ierr = 1;
+}
+
+print "Module '$smodulename': Execution finished with [$ierr]\n";
 
 
-
-
+exit $ierr;


### PR DESCRIPTION
During the analysis of the incident documented at
[Pre-Caching fails](https://github.com/bodo-hugo-barwich/plack-pwa-api/issues/9)
it was detected that many possible exceptions during the Cache Creation Process are not captured and processed correctly.
The Pre-Caching Script has special importance for the Docker Deploy in test environments where the `cache` directory is provided by the Web Site and will be found empty.